### PR TITLE
make empty string an invalid glob

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ isValidGlob('a');
 isValidGlob('a.js');
 isValidGlob('*.js');
 isValidGlob(['a', 'b']);
-isValidGlob('');
 isValidGlob([]);
 //=> all true
 ```
@@ -37,6 +36,7 @@ isValidGlob([]);
 
 ```js
 isValidGlob();
+isValidGlob('');
 isValidGlob({});
 isValidGlob(null);
 isValidGlob(undefined);
@@ -44,6 +44,7 @@ isValidGlob(new Buffer('foo'));
 isValidGlob(['foo', [[]]]);
 isValidGlob(['foo', [['bar']]]);
 isValidGlob(['foo', {}]);
+isValidGlob(['']);
 //=> all false
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function isValidGlob(glob) {
-  if (typeof glob === 'string') {
+  if (typeof glob === 'string' && glob.length > 0) {
     return true;
   }
   if (Array.isArray(glob)) {
@@ -13,7 +13,7 @@ module.exports = function isValidGlob(glob) {
 function every(arr) {
   var len = arr.length;
   while (len--) {
-    if (typeof arr[len] !== 'string') {
+    if (typeof arr[len] !== 'string' || arr[len].length <= 0) {
       return false;
     }
   }

--- a/test.js
+++ b/test.js
@@ -13,12 +13,12 @@ describe('isValidGlob', function () {
     assert.equal(isValidGlob(['a/**/*.js', '*.js']), true);
 
     // neither of these should blow up
-    assert.equal(isValidGlob(''), true);
     assert.equal(isValidGlob([]), true);
   });
 
   it('should return false when the pattern is not a valid glob pattern:', function () {
     assert.equal(isValidGlob(), false);
+    assert.equal(isValidGlob(''), false);
     assert.equal(isValidGlob({}), false);
     assert.equal(isValidGlob(null), false);
     assert.equal(isValidGlob(undefined), false);
@@ -26,5 +26,6 @@ describe('isValidGlob', function () {
     assert.equal(isValidGlob(['foo', [[]]]), false);
     assert.equal(isValidGlob(['foo', [['bar']]]), false);
     assert.equal(isValidGlob(['foo', {}]), false);
+    assert.equal(isValidGlob(['']), false);
   });
 });


### PR DESCRIPTION
either going to have to do it here or in vinyl-fs, but empty string patterns are a huge anti-pattern for people to do shit like `gulp.src('').pipe(somethingthatshouldntbeaPlugin())`

also probably going to send a PR for making empty arrays invalid as well
