### PR TITLE
empty arrays are now invalid globs

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function isValidGlob(glob) {
     return true;
   }
   if (Array.isArray(glob)) {
-    return every(glob);
+    return glob.length !== 0 && every(glob);
   }
   return false;
 };

--- a/test.js
+++ b/test.js
@@ -12,14 +12,13 @@ describe('isValidGlob', function () {
     assert.equal(isValidGlob(['a', 'b']), true);
     assert.equal(isValidGlob(['a/**/*.js', '*.js']), true);
 
-    // neither of these should blow up
-    assert.equal(isValidGlob([]), true);
   });
 
   it('should return false when the pattern is not a valid glob pattern:', function () {
     assert.equal(isValidGlob(), false);
     assert.equal(isValidGlob(''), false);
     assert.equal(isValidGlob({}), false);
+    assert.equal(isValidGlob([]), false);
     assert.equal(isValidGlob(null), false);
     assert.equal(isValidGlob(undefined), false);
     assert.equal(isValidGlob(new Buffer('foo')), false);


### PR DESCRIPTION
breaking change, but I think this is right. the only things that should be valid globs are things that are actually match-able
